### PR TITLE
Improve geo polygon search tests

### DIFF
--- a/src/commonTest/kotlin/GeoIndexTest.kt
+++ b/src/commonTest/kotlin/GeoIndexTest.kt
@@ -27,4 +27,24 @@ class GeoIndexTest {
         val polyHits = index.search { query = GeoPolygonQuery("loc", polygon) }
         polyHits.map { it.first } shouldContainExactlyInAnyOrder listOf("berlin")
     }
+
+    @Test
+    fun testPolygonContainmentAndIntersection() {
+        val geoIndex = GeoFieldIndex()
+        val index = DocumentIndex(mutableMapOf("loc" to geoIndex))
+
+        val berlinPoint = Geometry.Point.of(13.4, 52.5)
+        val berlinBox = doubleArrayOf(13.3, 52.4, 13.5, 52.6).toGeometry()
+
+        index.index(Document("berlin_point", mapOf("loc" to listOf(berlinPoint.toString()))))
+        index.index(Document("berlin_box", mapOf("loc" to listOf(berlinBox.toString()))))
+
+        val containingPoly = doubleArrayOf(13.0, 52.0, 14.0, 53.0).toGeometry().coordinates!!
+        val containHits = index.search { query = GeoPolygonQuery("loc", containingPoly) }
+        containHits.map { it.first } shouldContainExactlyInAnyOrder listOf("berlin_point", "berlin_box")
+
+        val overlappingPoly = doubleArrayOf(13.4, 52.5, 13.6, 52.7).toGeometry().coordinates!!
+        val overlapHits = index.search { query = GeoPolygonQuery("loc", overlappingPoly) }
+        overlapHits.map { it.first } shouldContain "berlin_box"
+    }
 }


### PR DESCRIPTION
## Summary
- add test covering polygon containment and intersection

## Testing
- `./gradlew jvmTest --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_684555440ae0832e818862710e393223