### PR TITLE
Add CLI index builder and JS wrapper

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -111,6 +111,13 @@ kotlin {
             }
         }
 
+        jvmMain {
+            dependencies {
+                implementation("org.jetbrains.kotlinx:kotlinx-cli:0.3.6")
+                implementation("org.yaml:snakeyaml:2.2")
+            }
+        }
+
         jvmTest {
             dependencies {
                 implementation(kotlin("test-junit"))

--- a/example.html
+++ b/example.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8" />
+    <title>Querylight Example</title>
+</head>
+<body>
+<input id="q" placeholder="search"/>
+<ul id="results"></ul>
+<script src="querylight.js"></script>
+<script>
+async function init() {
+    const resp = await fetch('index.json');
+    const json = await resp.text();
+    const engine = querylight.QuerylightJs.fromJson(json);
+    document.getElementById('q').addEventListener('input', ev => {
+        const term = ev.target.value;
+        const hits = engine.search(term, 10);
+        const ul = document.getElementById('results');
+        ul.innerHTML = '';
+        hits.forEach(id => {
+            const li = document.createElement('li');
+            li.textContent = id;
+            ul.appendChild(li);
+        });
+    });
+}
+init();
+</script>
+</body>
+</html>

--- a/src/jsMain/kotlin/QuerylightJs.kt
+++ b/src/jsMain/kotlin/QuerylightJs.kt
@@ -1,0 +1,31 @@
+@file:Suppress("NON_EXPORTABLE_TYPE")
+package search
+
+import kotlinx.serialization.json.Json
+
+@JsExport
+class QuerylightJs private constructor(private val index: DocumentIndex) {
+    companion object {
+        fun fromJson(json: String): QuerylightJs {
+            val state = Json.decodeFromString(DocumentIndexState.serializer(), json)
+            val idx = DocumentIndex(mutableMapOf()).loadState(state)
+            return QuerylightJs(idx)
+        }
+    }
+
+    fun search(term: String, limit: Int = 20): Array<String> {
+        val hits = index.search {
+            this.limit = limit
+            query = BoolQuery(
+                should = listOf(
+                    MatchQuery("title", term, prefixMatch = true),
+                    MatchQuery("content", term, prefixMatch = true),
+                    MatchQuery("tags", term, prefixMatch = true)
+                )
+            )
+        }
+        return hits.map { it.first }.toTypedArray()
+    }
+
+    fun document(id: String): Map<String, List<String>>? = index.get(id)?.fields
+}

--- a/src/jvmMain/kotlin/IndexBuilder.kt
+++ b/src/jvmMain/kotlin/IndexBuilder.kt
@@ -1,0 +1,76 @@
+import kotlinx.cli.ArgParser
+import kotlinx.cli.ArgType
+import kotlinx.cli.required
+import kotlinx.cli.default
+import kotlinx.cli.multiple
+import org.yaml.snakeyaml.Yaml
+import kotlinx.serialization.json.Json
+import java.io.File
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import search.*
+
+fun main(args: Array<String>) {
+    val parser = ArgParser("querylight-indexer")
+    val dirs by parser.option(ArgType.String, shortName = "d", description = "Directories to scan").multiple().required()
+    val output by parser.option(ArgType.String, shortName = "o", description = "Output file").required()
+    val datePattern by parser.option(ArgType.String, shortName = "p", description = "Date pattern in file name").default("yyyy-MM-dd'T'HH:mm'Z'")
+    parser.parse(args)
+
+    val formatter = DateTimeFormatter.ofPattern(datePattern)
+
+    val index = DocumentIndex(
+        mutableMapOf(
+            "content" to TextFieldIndex(),
+            "title" to TextFieldIndex(),
+            "tags" to TextFieldIndex(),
+            "createdAt" to TextFieldIndex()
+        )
+    )
+
+    val yaml = Yaml()
+
+    dirs.forEach { dir ->
+        File(dir).walk().filter { it.isFile && it.extension == "md" }.forEach { file ->
+            val text = file.readText()
+            val (meta, content) = parseFrontMatter(text, yaml)
+            val title = meta["title"]?.toString() ?: file.nameWithoutExtension
+            val tags = (meta["tags"] as? Iterable<*>)?.map { it.toString() } ?: emptyList()
+            val dateString = extractDate(file.nameWithoutExtension, formatter)
+            val fields = mutableMapOf(
+                "title" to listOf(title),
+                "content" to listOf(content)
+            )
+            if (tags.isNotEmpty()) fields["tags"] = tags
+            dateString?.let { fields["createdAt"] = listOf(it) }
+            val doc = Document(file.path, fields)
+            index.index(doc)
+        }
+    }
+
+    val json = Json.encodeToString(DocumentIndexState.serializer(), index.indexState)
+    File(output).writeText(json)
+}
+
+private fun parseFrontMatter(text: String, yaml: Yaml): Pair<Map<String, Any>, String> {
+    val re = Regex("^---\\s*([\\s\\S]*?)\\s*---\\s*(.*)", RegexOption.DOT_MATCHES_ALL)
+    val m = re.find(text)
+    return if (m != null) {
+        val meta = yaml.load<Map<String, Any>>(m.groupValues[1]) ?: emptyMap()
+        meta to m.groupValues[2].trim()
+    } else {
+        emptyMap<String, Any>() to text
+    }
+}
+
+private fun extractDate(name: String, formatter: DateTimeFormatter): String? {
+    val length = LocalDateTime.now().format(formatter).length
+    for (i in 0..name.length - length) {
+        val part = name.substring(i, i + length)
+        try {
+            val dt = LocalDateTime.parse(part, formatter)
+            return dt.toString()
+        } catch (_: Exception) { }
+    }
+    return null
+}


### PR DESCRIPTION
## Summary
- add a jvm main `IndexBuilder` that builds an index from markdown files
- export a JS friendly API `QuerylightJs`
- provide a small HTML example
- add CLI dependencies for JVM

## Testing
- `./gradlew jvmTest --no-build-cache --continue`

------
https://chatgpt.com/codex/tasks/task_e_6872267fe158832eb1c1dd3e71b83273