### PR TITLE
Fix MatchQuery AND intersection and add regression test

### DIFF
--- a/src/commonMain/kotlin/search/queries.kt
+++ b/src/commonMain/kotlin/search/queries.kt
@@ -139,26 +139,40 @@ class MatchQuery(
             if (operation == OP.AND) {
                 // start with the smallest list
                 val termHits = searchTerms.map {
-                    fieldIndex.searchTerm(it,prefixMatch)
+                    fieldIndex.searchTerm(it, prefixMatch)
                 }.sortedBy { it.size }
-                // quick check to see if we can return right away (if one of the terms did not match, we have no hits)
-                if (termHits.isEmpty() || termHits[0].isEmpty()) {
-                    listOf<Hit>()
-                } else {
-                    termHits.first().forEach { (docId, score) ->
-                        collectedHits[docId] = score
+
+                if (termHits.isEmpty()) {
+                    return emptyList()
+                }
+
+                var intersectedHits: MutableMap<String, Double>? = null
+
+                termHits.forEach { hits ->
+                    if (hits.isEmpty()) {
+                        return emptyList()
                     }
-                    // plenty of potential to optimize this later
-                    // if we have an efficient way to look up keys from sub lists, simply looking up each
-                    // of the keys in the smallest list in the other lists is potentially faster if we have
-                    // some terms with a lot of hits.
-                    termHits.subList(1, termHits.size).forEach {
-                        it.forEach { hit ->
-                            if (collectedHits.containsKey(hit.first)) {
-                                collectedHits[hit.first] = hit.second + (collectedHits[hit.first] ?: 0.0)
+
+                    if (intersectedHits == null) {
+                        intersectedHits = hits.associateTo(mutableMapOf()) { it.first to it.second }
+                    } else {
+                        val current = intersectedHits ?: mutableMapOf()
+                        val updated = mutableMapOf<String, Double>()
+                        hits.forEach { (docId, score) ->
+                            val previousScore = current[docId]
+                            if (previousScore != null) {
+                                updated[docId] = previousScore + score
                             }
                         }
+                        if (updated.isEmpty()) {
+                            return emptyList()
+                        }
+                        intersectedHits = updated
                     }
+                }
+
+                intersectedHits?.forEach { (docId, score) ->
+                    collectedHits[docId] = score
                 }
             } else {
                 val termHits = searchTerms.map { fieldIndex.searchTerm(it,prefixMatch) }

--- a/src/commonTest/kotlin/RankingTest.kt
+++ b/src/commonTest/kotlin/RankingTest.kt
@@ -41,4 +41,13 @@ class RankingTest {
         results[1].first shouldBe expected[1].first
         results[1].second shouldBe (expected[1].second plusOrMinus 1e-6)
     }
+
+    @Test
+    fun matchQueryWithAndRequiresAllTerms() {
+        val tfidf = index(RankingAlgorithm.TFIDF)
+        tfidf.search(MatchQuery("text", "foo baz", operation = OP.AND)) shouldBe emptyList()
+
+        val bm25 = index(RankingAlgorithm.BM25)
+        bm25.search(MatchQuery("text", "foo baz", operation = OP.AND)) shouldBe emptyList()
+    }
 }

--- a/src/jvmTest/kotlin/MatchQueryJvmTest.kt
+++ b/src/jvmTest/kotlin/MatchQueryJvmTest.kt
@@ -1,0 +1,58 @@
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import search.Document
+import search.DocumentIndex
+import search.MatchQuery
+import search.OP
+import search.RankingAlgorithm
+import search.TextFieldIndex
+
+class MatchQueryJvmTest {
+    private fun buildIndex(
+        rankingAlgorithm: RankingAlgorithm,
+        documents: List<Document>
+    ): DocumentIndex {
+        val index = DocumentIndex(mutableMapOf("text" to TextFieldIndex(rankingAlgorithm = rankingAlgorithm)))
+        documents.forEach(index::index)
+        return index
+    }
+
+    @Test
+    fun andOnlyReturnsDocsContainingAllTerms() {
+        val documents = listOf(
+            Document("1", mapOf("text" to listOf("alpha beta"))),
+            Document("2", mapOf("text" to listOf("alpha gamma"))),
+            Document("3", mapOf("text" to listOf("beta gamma")))
+        )
+
+        listOf(RankingAlgorithm.TFIDF, RankingAlgorithm.BM25).forEach { algorithm ->
+            val index = buildIndex(algorithm, documents)
+            val hits = index.search(MatchQuery("text", "alpha beta", operation = OP.AND))
+            assertEquals(listOf("1"), hits.map { it.first })
+        }
+    }
+
+    @Test
+    fun andAggregatesScoresForIntersectedDocs() {
+        val documents = listOf(
+            Document("1", mapOf("text" to listOf("alpha beta alpha"))),
+            Document("2", mapOf("text" to listOf("alpha alpha alpha"))),
+            Document("3", mapOf("text" to listOf("beta beta beta")))
+        )
+
+        listOf(RankingAlgorithm.TFIDF, RankingAlgorithm.BM25).forEach { algorithm ->
+            val index = buildIndex(algorithm, documents)
+            val hits = index.search(MatchQuery("text", "alpha beta", operation = OP.AND))
+
+            assertEquals(1, hits.size)
+            assertEquals("1", hits.first().first)
+
+            val fieldIndex = index.getFieldIndex("text") as TextFieldIndex
+            val expectedScore = listOf("alpha", "beta").sumOf { term ->
+                fieldIndex.searchTerm(term).firstOrNull { it.first == "1" }?.second ?: 0.0
+            }
+
+            assertEquals(expectedScore, hits.first().second, 1e-10)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- ensure MatchQuery AND operations intersect per-term hits and only sum scores for surviving documents
- add regression coverage asserting AND queries return no hits when terms are missing under TFIDF and BM25 rankings

## Testing
- ./gradlew jvmTest --console=plain --no-daemon
- ./gradlew check --console=plain --no-daemon *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_68d271c0bfbc832ebfd06d734688044d