### PR TITLE
Fix prefix term frequency handling

### DIFF
--- a/src/commonMain/kotlin/search/TextFieldIndex.kt
+++ b/src/commonMain/kotlin/search/TextFieldIndex.kt
@@ -75,11 +75,21 @@ class TextFieldIndex(
      * Returns a list of docId to tf/idf score
      */
     fun searchTerm(term: String, allowPrefixMatch: Boolean = false): List<Hit> {
-        val matches = termMatches(term) ?: if (allowPrefixMatch) {
-            trie.match(term).flatMap { t -> termMatches(t) ?: listOf() }.distinct().takeIf { it.isNotEmpty() }
-        } else null
+        val matches = mutableListOf<TermPos>()
+        termMatches(term)?.let { matches.addAll(it) }
 
-        return matches?.let { calculateScore(it.map { it.id }) } ?: emptyList()
+        if (allowPrefixMatch) {
+            trie.match(term).forEach { matchedTerm ->
+                termMatches(matchedTerm)?.let { matches.addAll(it) }
+            }
+        }
+
+        val uniqueMatches = matches.distinct()
+        return if (uniqueMatches.isNotEmpty()) {
+            calculateScore(uniqueMatches.map { it.id })
+        } else {
+            emptyList()
+        }
     }
 
     fun searchPhrase(terms: List<String>, slop: Int = 0): List<Hit> {
@@ -108,7 +118,9 @@ class TextFieldIndex(
 
     fun searchPrefix(prefix: String): List<Hit> {
         val terms = trie.match(prefix)
-        val docIds = terms.flatMap { termMatches(it)?.map { it.id } ?: listOf() }.distinct()
+        val docIds = terms.flatMap { term ->
+            termMatches(term)?.map { it.id } ?: emptyList()
+        }
         return calculateScore(docIds)
     }
 

--- a/src/jvmTest/kotlin/MatchQueryJvmTest.kt
+++ b/src/jvmTest/kotlin/MatchQueryJvmTest.kt
@@ -1,5 +1,6 @@
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 import search.Document
 import search.DocumentIndex
 import search.MatchQuery
@@ -53,6 +54,28 @@ class MatchQueryJvmTest {
             }
 
             assertEquals(expectedScore, hits.first().second, 1e-10)
+        }
+    }
+
+    @Test
+    fun prefixMatchesAccumulateTermFrequency() {
+        val documents = listOf(
+            Document("1", mapOf("text" to listOf("carpet carpool car drive"))),
+            Document("2", mapOf("text" to listOf("car drive drive drive"))),
+            Document("3", mapOf("text" to listOf("dog")))
+        )
+
+        listOf(RankingAlgorithm.TFIDF, RankingAlgorithm.BM25).forEach { algorithm ->
+            val index = buildIndex(algorithm, documents)
+            val matchQueryHits = index.search(MatchQuery("text", "car", prefixMatch = true))
+            assertEquals(listOf("1", "2"), matchQueryHits.map { it.first })
+            assertTrue(matchQueryHits[0].second > matchQueryHits[1].second)
+
+            val fieldIndex = index.getFieldIndex("text") as TextFieldIndex
+            val prefixHits = fieldIndex.searchPrefix("car")
+
+            assertEquals(listOf("1", "2"), prefixHits.map { it.first })
+            assertTrue(prefixHits[0].second > prefixHits[1].second)
         }
     }
 }


### PR DESCRIPTION
## Summary
- ensure prefix-enabled term searches include all matching occurrences when scoring
- pass duplicate document hits to `calculateScore` for prefix lookups
- add a JVM test covering BM25 and TF-IDF prefix queries with repeated matches

## Testing
- ./gradlew jvmTest --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68d2998f12d8832ebd9edc74ccc4b187